### PR TITLE
feat : @FutureOrPresent 어노테이션이 너무 타이트 하다는 의견이 나와 커스텀 어노테이션을 구현하여 하루 정…

### DIFF
--- a/src/main/java/com/example/eroom/domain/chat/customannotation/RelaxedFutureOrPresent.java
+++ b/src/main/java/com/example/eroom/domain/chat/customannotation/RelaxedFutureOrPresent.java
@@ -1,0 +1,22 @@
+package com.example.eroom.domain.chat.customannotation;
+
+import com.example.eroom.domain.chat.validator.RelaxedFutureOrPresentValidator;
+import jakarta.validation.Constraint;
+import org.springframework.messaging.handler.annotation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = RelaxedFutureOrPresentValidator.class)
+public @interface RelaxedFutureOrPresent {
+
+    String message() default "시작 날짜는 어제 이후여야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/eroom/domain/chat/dto/request/ProjectCreateRequestDTO.java
+++ b/src/main/java/com/example/eroom/domain/chat/dto/request/ProjectCreateRequestDTO.java
@@ -1,5 +1,6 @@
 package com.example.eroom.domain.chat.dto.request;
 
+import com.example.eroom.domain.chat.customannotation.RelaxedFutureOrPresent;
 import com.example.eroom.domain.entity.ColorInfo;
 import jakarta.validation.constraints.*;
 import lombok.Data;
@@ -25,7 +26,8 @@ public class ProjectCreateRequestDTO {
     @NotEmpty(message = "최소 하나 이상의 서브 카테고리를 선택해야 합니다.")
     private List<SubCategoryRequest> subCategories;
 
-    @FutureOrPresent(message = "시작 날짜는 현재 또는 미래여야 합니다.")
+//    @FutureOrPresent(message = "시작 날짜는 현재 또는 미래여야 합니다.")
+    @RelaxedFutureOrPresent(message = "시작 날짜는 어제 이후여야 합니다.")
     private LocalDateTime startDate;
 
     @Future(message = "종료 날짜는 미래여야 합니다.")

--- a/src/main/java/com/example/eroom/domain/chat/dto/request/TaskCreateRequestDTO.java
+++ b/src/main/java/com/example/eroom/domain/chat/dto/request/TaskCreateRequestDTO.java
@@ -1,5 +1,6 @@
 package com.example.eroom.domain.chat.dto.request;
 
+import com.example.eroom.domain.chat.customannotation.RelaxedFutureOrPresent;
 import com.example.eroom.domain.entity.ColorInfo;
 import com.example.eroom.domain.entity.TaskStatus;
 import jakarta.validation.constraints.*;
@@ -17,7 +18,8 @@ public class TaskCreateRequestDTO {
     @Size(max = 50, message = "테스크 이름은 최대 50자까지 가능합니다.")
     private String title;
 
-    @FutureOrPresent(message = "시작 날짜는 현재 또는 미래여야 합니다.")
+//    @FutureOrPresent(message = "시작 날짜는 현재 또는 미래여야 합니다.")
+    @RelaxedFutureOrPresent(message = "시작 날짜는 어제 이후여야 합니다.")
     private LocalDateTime startDate;
 
     @Future(message = "종료 날짜는 미래여야 합니다.")

--- a/src/main/java/com/example/eroom/domain/chat/validator/RelaxedFutureOrPresentValidator.java
+++ b/src/main/java/com/example/eroom/domain/chat/validator/RelaxedFutureOrPresentValidator.java
@@ -1,0 +1,20 @@
+package com.example.eroom.domain.chat.validator;
+
+import com.example.eroom.domain.chat.customannotation.RelaxedFutureOrPresent;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDateTime;
+
+public class RelaxedFutureOrPresentValidator implements ConstraintValidator<RelaxedFutureOrPresent, LocalDateTime> {
+
+    @Override
+    public boolean isValid(LocalDateTime value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true; // null 검증 x
+        }
+
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        return !value.isBefore(yesterday); // 어제 이후면 통과
+    }
+}


### PR DESCRIPTION
…도는 과거를 허용.

## 🔎 작업 내용

- 커스텀 어노테이션을 구현하여 @FutureOrPresent 검증에 대한 느슨한 검증을 구현(하루 정도는 과거 허용)

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->