### PR TITLE
feat: (임시) 회원탈퇴기능 추가, fix: 마이페이지 수정할 때 profileImage를 보내지 않으면 null이 들어가도록 수정

### DIFF
--- a/src/main/java/com/example/eroom/domain/auth/service/MyPageService.java
+++ b/src/main/java/com/example/eroom/domain/auth/service/MyPageService.java
@@ -2,7 +2,9 @@ package com.example.eroom.domain.auth.service;
 
 import com.example.eroom.domain.auth.dto.request.MyPageUpdateRequestDTO;
 import com.example.eroom.domain.auth.repository.AuthMemberRepository;
+import com.example.eroom.domain.entity.DeleteStatus;
 import com.example.eroom.domain.entity.Member;
+import com.example.eroom.domain.entity.MemberGrade;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
@@ -19,7 +22,6 @@ public class MyPageService {
     private final AmazonS3Service amazonS3Service;
     private final EntityManager entityManager;
 
-    @Transactional
     public Member updateMyPage(Member member, MyPageUpdateRequestDTO requestDTO, MultipartFile profileImage) {
         Member existingMember = memberRepository.findById(member.getId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
@@ -40,11 +42,26 @@ public class MyPageService {
             updatedMember = updatedMember.toBuilder()
                     .profile(newProfileUrl)
                     .build();
+        } else { // 이미지가 null이라면
+            if (existingMember.getProfile() != null) {
+                amazonS3Service.deleteFile(existingMember.getProfile());
+            }
+            updatedMember = updatedMember.toBuilder()
+                    .profile(null) // 프로필을 null로 설정
+                    .build();
         }
 
         memberRepository.save(updatedMember);
 
         return updatedMember;
+    }
+
+    // 회원 탈퇴
+    public void deleteMember(Member member) {
+        Member updatedMember = member.toBuilder()
+                .deleteStatus(DeleteStatus.DELETED)
+                .build();
+        memberRepository.save(updatedMember); // 변경된 상태로 저장
     }
 
 }


### PR DESCRIPTION
fix: 마이페이지 수정할 때 profileImage를 보내지 않으면 null이 들어가도록 수정

## 🔎 작업 내용

- (임시) 회원탈퇴기능 추가
- 마이페이지 수정할 때 profileImage를 보내지 않으면 null이 들어가도록 수정

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 작업

- 앞으로의 작업 또는 완료 사항

## 🔗 References

<!-- 관련된 이슈, PR, 링크 등을 첨부해 주세요 -->

- Issue: #

## 💬 Comments

<!-- 추가적인 커멘트가 있다면 작성해 주세요 -->